### PR TITLE
release condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,14 @@ jobs:
           echo "version_major=$MAJOR" >> $GITHUB_ENV
           echo "version_minor=$MINOR" >> $GITHUB_ENV
           echo "version_patch=$PATCH" >> $GITHUB_ENV
-
-      - name: Update pyproject.toml with new version
+      
+      - name: Verify version consistency
         run: |
-          poetry version ${{ env.version }}  # Updates version in pyproject.toml
+          POETRY_VERSION=$(poetry version --short)
+          if [ "$POETRY_VERSION" != "${{ env.VERSION }}" ]; then
+            echo "Version in pyproject.toml ($POETRY_VERSION) does not match the Git tag (${{ env.VERSION }})"
+            exit 1
+          fi
 
       - name: Build and Publish to PyPI
         run: poetry publish --build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lib-ml
 Contains the pre-processing logic for data that is used for training or queries.
 
-## Release
+## Automated Release & Versioning
 
 1. Update the version number in `pyproject.toml`.
 
@@ -34,4 +34,10 @@ git tag vA.B.C
 git push origin vA.B.C
 ```
 
-The last action will trigger the automated release workflow. The workflow will create a new release with the version number.
+The last action will trigger the automated release workflow.
+
+## Implementation Details
+
+* To publish to PyPi, we created an API Token and added it to the GitHub repository secrets.
+* The token is stored in the `PYPI_API_TOKEN` secret.
+* The release worfklow fails if the you did not set the `pyproject.toml` version number to be the same as the tag version number.


### PR DESCRIPTION
- only allow the release workflow to publish the package if the `pyproject.toml` version number is the same as that of the git tag
- this is done to maintain consistency